### PR TITLE
Classy work around.

### DIFF
--- a/projecto/blueprints/v_api_v1.py
+++ b/projecto/blueprints/v_api_v1.py
@@ -42,7 +42,7 @@ class ProjectsView(FlaskView):
 
     return jsonify(owned=projects_owned, participating=projects_participating)
 
-  @route("/<id>", methods=["GET"])
+  @route("/<project_id>", methods=["GET"])
   @project_access_required
   def get(self, project):
     if current_user.key in project.owners:
@@ -50,8 +50,8 @@ class ProjectsView(FlaskView):
     else:
       return jsonify(**project.serialize(restricted=("owners", "collaborators", "unregistered_collaborators", "unregistered_owners"), include_key=True))
 
-  @route("/<id>/stats", methods=["GET"])
-  def stats(self, id):
+  @route("/<project_id>/stats", methods=["GET"])
+  def stats(self, project):
     pass
 
 ProjectsView.register(blueprint)


### PR DESCRIPTION
So now tests works.. The reason this works is because flask routing
passes the attribute using kwargs. In this case, the self parameter gets
passed into `args`. When we pass project, we pass via project=project
and the self gets passed into the correct location as a part of `*args`.

Probably not a perma-solution. Still gotta refer to the comments in #16.
