### PR TITLE
Fix for pagination with filter

### DIFF
--- a/projecto/blueprints/v_api_v1.py
+++ b/projecto/blueprints/v_api_v1.py
@@ -3,6 +3,7 @@ from flask.ext.login import login_required, current_user
 from flask.ext.classy import FlaskView, route
 import settings
 import os
+import math
 
 from leveldbkit import NotFoundError
 
@@ -225,6 +226,10 @@ class TodosView(FlaskView):
 
     filtered.sort(key=lambda x: x["date"], reverse=True)
     totalTodos = len(filtered)
+    if (totalTodos < (page*amount + 1)):
+      page = int(math.ceil(totalTodos / amount)) - 1
+      if (page < 0):
+        page = 0
 
     return jsonify(todos=filtered[page*amount:page*amount+amount],
                    currentPage=page+1, totalTodos=totalTodos, todosPerPage=amount)

--- a/projecto/blueprints/v_api_v1.py
+++ b/projecto/blueprints/v_api_v1.py
@@ -126,16 +126,6 @@ class TodosView(FlaskView):
   route_base = "/projects/<project_id>/todos/"
   decorators = [project_access_required]
 
-  # NOTE: Can't use this because of the class decorator
-  #
-  # def get_amount_and_page(args):
-  #   try:
-  #     amount = min(int(args.get("amount", 20)), 100)
-  #     page = int(args.get("page", 1)) - 1
-  #   except:
-  #     raise
-  #   return (amount, page)
-
   @route("/", methods=["POST"])
   @ensure_good_request({"title"}, {"title", "content", "assigned", "due", "tags"})
   def post(self, project):

--- a/static/js/develop/app.js
+++ b/static/js/develop/app.js
@@ -19,7 +19,7 @@
     });
 
     $routeProvider.when("/projects/:id/todos", todosPage);
-    $routeProvider.when("/projects/:id/todos/pages/:page", todosPage)
+    // $routeProvider.when("/projects/:id/todos/pages/:page", todosPage)   
 
     $routeProvider.when("/projects/:id/todos/:todoId", {
       templateUrl: "/static/partials/singletodo.html",

--- a/static/js/develop/app.js
+++ b/static/js/develop/app.js
@@ -19,7 +19,6 @@
     });
 
     $routeProvider.when("/projects/:id/todos", todosPage);
-    // $routeProvider.when("/projects/:id/todos/pages/:page", todosPage)   
 
     $routeProvider.when("/projects/:id/todos/:todoId", {
       templateUrl: "/static/partials/singletodo.html",

--- a/static/js/develop/controllers/todos.js
+++ b/static/js/develop/controllers/todos.js
@@ -22,14 +22,6 @@
         $scope.totalTodos = totalTodos;
         $scope.totalPages = Math.ceil(totalTodos / todosPerPage);
 
-        // NOTE: We can comment this out but we still need
-        //       to add pagination for filtered todos.
-        // if ($scope.totalPages === null) {
-        //   $scope.totalTodos = 0;
-        //   $scope.totalPages = null;
-        //   return;
-        // }
-
         // NOTE: This array is used in the template, for pagination.
         //       It will be eliminated when the pagination template
         //       is made into a directive.
@@ -156,7 +148,7 @@
 
         TodosService.filter($scope.currentProject, params)
           .done(function(data) {
-            showTodosUpdate(data, msg)
+            showTodosUpdate(data, msg);
           })
           .fail(function(xhr){
             $("body").statusmsg("open", "Updating todos failed: " + xhr.status, {type: "error", closable: true});
@@ -287,19 +279,6 @@
         }
       };
 
-      // NOTE: This should be removed before the next PR
-      //
-      // var filter = function(tags) {
-      //   var params = {
-      //     tags: tags,
-      //     showdone: $scope.showdone,
-      //     shownotdone: $scope.shownotdone,
-      //     page: ($route.current.params.page || 1)
-      //   };
-
-      //   return TodosService.filter($scope.currentProject, params).done(showTodosUpdate);
-      // };
-
       $scope.checkTagFilter = function(tag) {
         $scope.tagsFiltered[tag] = !$scope.tagsFiltered[tag];
         $scope.update();
@@ -355,5 +334,5 @@
 })();
 
 
-// NOTE: CLICKING ANY FILTER BOX WILL CLOSE ANY EDIT FORM CURRENTLY OPEN. I BELIEVE THAT THIS IS ACCEPTABLE
-//       BEHAVIOR
+// NOTE: Clicking any filter box will close any Edit form currently open. I believe that this is acceptable
+//       behavior

--- a/static/js/develop/controllers/todos.js
+++ b/static/js/develop/controllers/todos.js
@@ -20,13 +20,16 @@
 
       var recomputePages = function(totalTodos, todosPerPage) {
         $scope.totalTodos = totalTodos;
-        $scope.totalPages = Math.floor(totalTodos / todosPerPage) + (totalTodos % todosPerPage == 0 ? 0 : 1);
+        $scope.totalPages = Math.ceil(totalTodos / todosPerPage);
+
+        // QUESTION: Why would totalPages ever be null?
         if ($scope.totalPages === null) {
           $scope.totalTodos = 0;
           $scope.totalPages = null;
           return;
         }
 
+        // QUESTION: What's the point of this array?
         $scope.pages = [];
         if ($scope.totalPages < 8) {
           for (var i=1; i<=$scope.totalPages; i++)
@@ -247,11 +250,11 @@
         return TodosService.filter($scope.currentProject, params).done(function(data) {
           $scope.$apply(function() {
             $scope.todos = data.todos;
-            $scope.currentPage = null;
+            $scope.currentPage = 1;
             $scope.totalPages = null;
-            $scope.todosPerPage = null;
             $scope.totalTodos = data.todos.length;
             $scope.pages = [];
+            recomputePages($scope.totalTodos, $scope.todosPerPage);
           });
         });
       };

--- a/static/js/develop/controllers/todos.js
+++ b/static/js/develop/controllers/todos.js
@@ -156,7 +156,6 @@
       };
 
       $scope.update = function(msg) {
-        console.log("Updating the todos list");
         TodosService.listTags($scope.currentProject)
           .done(function(data) {
             updateTags(data);

--- a/static/js/develop/controllers/todos.js
+++ b/static/js/develop/controllers/todos.js
@@ -39,7 +39,7 @@
           $scope.currentPage = data.currentPage;
           recomputePages(data.totalTodos, data.todosPerPage);
           if (msg) {
-            $("body").statusmsg("open", msg, {type: "success", autoclose: 500});
+            $("body").statusmsg("open", msg, {type: "success", autoclose: 2000});
           }
         });
       };
@@ -250,7 +250,7 @@
               }
               else {
                 $scope.todos[i] = data;
-                $("body").statusmsg("open", msg, {type: "success", autoclose: 1000});
+                $("body").statusmsg("open", msg, {type: "success", autoclose: 2000});
               }
             });
             toggleTodo(data, "open");

--- a/static/js/develop/controllers/todos.js
+++ b/static/js/develop/controllers/todos.js
@@ -230,9 +230,9 @@
 
       var cancelAction = function(action) {
         if (currentlyEditing()) {
-          action = action || "proceed";
-          var msg = "There are todo items currently being edited on this page.\n";
-          msg += "Are you sure that you wish to " + action + "? (Unsaved changes will be lost)";
+          var msg = action ? "You are about to " + action + ".\n" : "Warning!\n";
+          msg += "This action will reload the todo items, but you have items currently open for editing. ";
+          msg += "Any unsaved changes will be lost.\nDo you wish to proceed?";
           if (!window.confirm(msg)) {
             return true;
           }

--- a/static/partials/todos.html
+++ b/static/partials/todos.html
@@ -68,8 +68,6 @@
   <div class="large-9 columns">
     <div class="panel" ng-repeat="todo in todos">
 
-      <!-- SUGGESTION: Make a separate todoItem template + controller -->
-
       <form class="custom">
         <span class="custom checkbox todos-todo-donebox" ng-class="{checked: todo.done}" ng-click="markDone(todo)"></span>
         <span class="todos-control">
@@ -88,9 +86,6 @@
       </form>
 
 
-      <!-- QUESTION: What dictates whether this <div> is created or not? Not obvious by looking at this
-                     template that this is usually hidden 
-      -->
       <div class="todos-todo-body" id="todo-{[ todo.key ]}">
 
         <!-- view mode -->
@@ -137,19 +132,9 @@
 
 
     <!-- Pagination -->
-
-    <!-- IDEA: Make pagination its own modular component, so we can re-use it on other pages-->
-
-    <!-- IDEA: For the <ul>, make ng-show="1 < totalPages", use a single <li> with ng-repeat, 
-               link ng-show to a function, make ng-class="{current: i == currentPage}", make &hellip; element
-               hide with the same function linked to ng-show 
-    -->
-
     <ul class="pagination right" ng-show="1 < totalPages && totalPages < 9">
       <li ng-repeat="i in pages" ng-class="{current: i == currentPage}"><a href="" ng-click="goToPage({[i]})">{[ i ]}</a></li>
     </ul>
-
-    
 
     <ul class="pagination right" ng-show="totalPages >= 9">
       <li ng-class="{current: currentPage == 1}"><a href="" ng-click="goToPage(1)">1</a></li>

--- a/static/partials/todos.html
+++ b/static/partials/todos.html
@@ -148,23 +148,23 @@
     -->
 
     <ul class="pagination right" ng-show="1 < totalPages && totalPages < 9">
-      <li ng-repeat="i in pages" ng-class="{current: i == currentPage}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ i ]}">{[ i ]}</a></li>
+      <li ng-repeat="i in pages" ng-class="{current: i == currentPage}"><a href="" ng-click="goToPage({[i]})">{[ i ]}</a></li>
     </ul>
 
     
 
     <ul class="pagination right" ng-show="totalPages >= 9">
-      <li ng-class="{current: currentPage == 1}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/1">1</a></li>
-      <li ng-class="{current: currentPage == 2}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/2">2</a></li>
-      <li ng-show="currentPage == 2"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ 3 ]}">3</a></li>
+      <li ng-class="{current: currentPage == 1}"><a href="" ng-click="goToPage(1)">1</a></li>
+      <li ng-class="{current: currentPage == 2}"><a href="" ng-click="goToPage(2)">2</a></li>
+      <li ng-show="currentPage == 2"><a href="" ng-click="goToPage(3)">3</a></li>
       <li class="unavailable" ng-hide="currentPage == 3 || currentPage == 4">&hellip;</li>
-      <li ng-show="3 < currentPage && currentPage < totalPages-1"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ currentPage-1 ]}">{[ currentPage-1 ]}</a></li>
-      <li ng-show="2 < currentPage && currentPage < totalPages-1" class="current"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ currentPage ]}">{[ currentPage ]}</a></li>
-      <li ng-show="2 < currentPage && currentPage < totalPages-2"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ currentPage+1 ]}">{[ currentPage+1 ]}</a></li>
+      <li ng-show="3 < currentPage && currentPage < totalPages-1"><a href="" ng-click="goToPage({[ currentPage-1 ]})">{[ currentPage-1 ]}</a></li>
+      <li ng-show="2 < currentPage && currentPage < totalPages-1" class="current"><a href="" ng-click="goToPage({[ currentPage ]})">{[ currentPage ]}</a></li>
+      <li ng-show="2 < currentPage && currentPage < totalPages-2"><a href="" ng-click="goToPage({[ currentPage+1 ]})">{[ currentPage+1 ]}</a></li>
       <li class="unavailable" ng-hide="currentPage >= totalPages-3 || currentPage <= 2">&hellip;</li>
-      <li ng-show="currentPage == totalPages-1"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ totalPages-2 ]}">{[ totalPages-2 ]}</a></li>
-      <li ng-class="{current: currentPage == totalPages-1}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ totalPages-1 ]}">{[ totalPages-1 ]}</a></li>
-      <li ng-class="{current: currentPage == totalPages}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ totalPages ]}">{[ totalPages ]}</a></li>
+      <li ng-show="currentPage == totalPages-1"><a href="" ng-click="goToPage({[ totalPages-2 ]})">{[ totalPages-2 ]}</a></li>
+      <li ng-class="{current: currentPage == totalPages-1}"><a href="" ng-click="goToPage({[ totalPages-1 ]})">{[ totalPages-1 ]}</a></li>
+      <li ng-class="{current: currentPage == totalPages}"><a href="" ng-click="goToPage({[ totalPages ]})">{[ totalPages ]}</a></li>
     </ul>
   </div>
 </div>

--- a/static/partials/todos.html
+++ b/static/partials/todos.html
@@ -78,7 +78,7 @@
             <ng-pluralize count="todo.children.length" when="{'0': 'Comment', '1': '1 comment', 'other': '{} comments'}"></ng-pluralize>
           </a>
           <span ng-show="currentProject.owner || currentUser.key == todo.author.key">
-            | <a href="" titile="Edit" ng-click="editTodo(todo, $index)">Edit</a> |
+            | <a href="" title="Edit" ng-click="editTodo(todo, $index)">Edit</a> |
             <a href="" title="Delete" ng-click="deleteTodo(todo, $index)">Delete</a>
           </span>
         </span>
@@ -137,8 +137,6 @@
 
 
     <!-- Pagination -->
-
-    <!-- NOTE: For issue #5, something must be wrong with totalPages -->
 
     <!-- IDEA: Make pagination its own modular component, so we can re-use it on other pages-->
 

--- a/static/partials/todos.html
+++ b/static/partials/todos.html
@@ -1,5 +1,7 @@
 <div class="row">
   <div class="large-12 columns">
+
+    <!-- Top buttons -->
     <div class="right">
       <a href="" ng-click="clearDone()" class="small secondary button" ng-show="showdone">Clear Done</a>
       <a href="" ng-click="expandTodos($event)" class="small secondary button">Expand All</a>
@@ -7,6 +9,8 @@
     </div>
     <a href="#/projects/{[ currentProject.key ]}/todos/" class="small secondary button">All Todos</a>
     <a href="#/projects/{[ currentProject.key ]}/milestones/" class="small secondary button">Milestones</a>
+
+    <!-- "New Todo" form -->
     <div class="panel" id="todos-new-todo">
       <h5>New Todo</h5>
       <form ng-submit="createTodo()">
@@ -40,6 +44,8 @@
 </div>
 
 <div class="row">
+
+  <!-- Filter panel -->
   <div class="large-3 columns">
     <div class="panel">
       <h6>Filter</h6>
@@ -57,10 +63,15 @@
       <p>Number of Todos: {[ totalTodos ]}</p>
     </div>
   </div>
+
+  <!-- Todo list -->
   <div class="large-9 columns">
     <div class="panel" ng-repeat="todo in todos">
+
+      <!-- SUGGESTION: Make a separate todoItem template + controller -->
+
       <form class="custom">
-        <span ng-class="{custom: true, checkbox: true, checked: todo.done, 'todos-todo-donebox': true}" ng-click="markDone(todo)"></span>
+        <span class="custom checkbox todos-todo-donebox" ng-class="{checked: todo.done}" ng-click="markDone(todo)"></span>
         <span class="todos-control">
           <span class="radius label" ng-show="todo.due">Due {[ todo.due | relativeTime ]}</span>
           <a href="#/projects/{[ currentProject.key ]}/todos/{[ todo.key ]}">
@@ -77,13 +88,16 @@
       </form>
 
 
+      <!-- QUESTION: What dictates whether this <div> is created or not? Not obvious by looking at this
+                     template that this is usually hidden 
+      -->
       <div class="todos-todo-body" id="todo-{[ todo.key ]}">
 
         <!-- view mode -->
         <div ng-show="!editMode[todo.key]">
-          <div class="todos-todo-content" ng-bind-html-unsafe="todo.content.html" ng-show="todo.content.markdown">
+          <div ng-show="todo.content.markdown" class="todos-todo-content" ng-bind-html-unsafe="todo.content.html">
           </div>
-          <div class="todos-todo-content" ng-show="!todo.content.markdown">
+          <div ng-hide="todo.content.markdown" class="todos-todo-content" >
             <p>No description provided.</p>
           </div>
           <div class="todos-todo-info">
@@ -121,9 +135,23 @@
       <p>No todo items. Hurray!</p>
     </div>
 
+
+    <!-- Pagination -->
+
+    <!-- NOTE: For issue #5, something must be wrong with totalPages -->
+
+    <!-- IDEA: Make pagination its own modular component, so we can re-use it on other pages-->
+
+    <!-- IDEA: For the <ul>, make ng-show="1 < totalPages", use a single <li> with ng-repeat, 
+               link ng-show to a function, make ng-class="{current: i == currentPage}", make &hellip; element
+               hide with the same function linked to ng-show 
+    -->
+
     <ul class="pagination right" ng-show="1 < totalPages && totalPages < 9">
-      <li ng-class="{current: i == currentPage}" ng-repeat="i in pages"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ i ]}">{[ i ]}</a></li>
+      <li ng-repeat="i in pages" ng-class="{current: i == currentPage}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/{[ i ]}">{[ i ]}</a></li>
     </ul>
+
+    
 
     <ul class="pagination right" ng-show="totalPages >= 9">
       <li ng-class="{current: currentPage == 1}"><a href="#/projects/{[ currentProject.key ]}/todos/pages/1">1</a></li>


### PR DESCRIPTION
Filtered todo results are now paginated. Many parts of the Todos controller code have been changed so that many functions now point to `$scope.update()`. Also, the todos list is always provided with a call to `/filter`, never to the index route. The `$scope.update()` function can also be provided an optional message that will appears after a successful update. Finally, a Python unittest was added for the `/filter` route.

Fixes [issue 5](https://github.com/shuhaowu/projecto/issues/5)
